### PR TITLE
Fix stack buffer overflows reported in gentoo bug 543310

### DIFF
--- a/libdiffball/bdelta.c
+++ b/libdiffball/bdelta.c
@@ -171,6 +171,8 @@ bdeltaReconstructDCBuff(DCB_SRC_ID src_id, cfile *patchf, CommandBuffer *dcbuff)
 	cread(patchf, buff, 1);
 	int_size = buff[0];
 	v2printf("int_size=%u\n", int_size);
+	if(int_size < 1 || int_size > 4)
+		return PATCH_CORRUPT_ERROR;
 	/* yes, this is an intentional switch fall through. */
 	switch(int_size) {
 		case 1: or_mask |= 0x0000ff00;

--- a/libdiffball/gdiff.c
+++ b/libdiffball/gdiff.c
@@ -192,7 +192,7 @@ signed int
 gdiffReconstructDCBuff(DCB_SRC_ID  src_id, cfile *patchf, CommandBuffer *dcbuff, 
 		unsigned int offset_type)
 {
-	const unsigned int buff_size = 5;
+	const unsigned int buff_size = 13;
 	unsigned char buff[buff_size];
 	off_u32 len, dc_pos=0;
 	off_u64 ver_pos=0;

--- a/libdiffball/xdelta1.c
+++ b/libdiffball/xdelta1.c
@@ -54,7 +54,7 @@ readXDInt(cfile *patchf, unsigned char *buff)
 	do {
 		count++;
 		cread(patchf, buff + count, 1);
-	} while(buff[count] & 0x80);
+	} while(count < 31 && buff[count] & 0x80);
 	for(; count >= 0; count--) {
 		num <<= 7;
 		num |= (buff[count] & 0x7f); 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/543310
Reported-by: Aidan Thornton <makosoft@googlemail.com>
Signed-off-by: Zac Medico <zmedico@gentoo.org>

Zac Medico (3):
  bdeltaReconstructDCBuff: validate int_size
  gdiffReconstructDCBuff: increase buff_size from 5 to 13
  readXDInt: limit count to 31

 libdiffball/bdelta.c  | 2 ++
 libdiffball/gdiff.c   | 2 +-
 libdiffball/xdelta1.c | 2 +-
 3 files changed, 4 insertions(+), 2 deletions(-)